### PR TITLE
Fixes issue #5: remove single quotes from remote command

### DIFF
--- a/POCSAGLocalTime
+++ b/POCSAGLocalTime
@@ -14,7 +14,7 @@ import configparser
 def SendMessage():
     now = datetime.now()
     localtime = now.strftime('%y%m%d%H%M%S')
-    command = ['RemoteCommand', '7642', 'page', '224', f'"YYYYMMDDHHMMSS{localtime}"']
+    command = ['RemoteCommand', '7642', 'page', '224', f"YYYYMMDDHHMMSS{localtime}"]
     try:
         result = subprocess.run(command, check=True)
         logger.info(f'Sending message in slot {next_timeslot} to 0000224, type 6, func Alphanumeric: "YYYYMMDDHHMMSS{localtime}"')


### PR DESCRIPTION
My pager (an Alphapoc GP2009N) was seeing the remote time command as a text message.  After messing with the code, I found out that removing the single quotes from the `command` F-string had fixed the issue.  This PR will resolve it for everyone.

I don't speak Python, but I tried fixing the code anyway. Someone who is familiar with the language should review my work and make sure that my change doesn't introduce any unwanted side effects. All I can say is that it made my pager set its time over the air.