### PR TITLE
Move systemd unit file from /lib to /etc

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -2,7 +2,7 @@
 sudo cp POCSAGLocalTime /usr/local/bin/
 sudo chown mmdvm:mmdvm /usr/local/bin/POCSAGLocalTime
 sudo chmod +x /usr/local/bin/POCSAGLocalTime
-sudo cp pocsaglocaltime.service /lib/systemd/system/
+sudo cp pocsaglocaltime.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl start pocsaglocaltime
 sudo systemctl enable pocsaglocaltime


### PR DESCRIPTION
The systemd file hierarchy recommends that administrator-provided units be installed in `/etc/systemd/system`, while unit files that are provided by the distribution be placed in `/lib/systemd/system` or `/usr/lib/systemd/system`. Per Table 1 in the the `systemd.unit` man page:

> /etc/systemd/system	System units created by the administrator.
>
> /lib/systemd/system	System units installed by the distribution package manager.

As this script is not a part of any distribution nor installed by any package manager, this commit moves the installation script to `/etc/systemd/system`.

That being said, if you know anything about Pi-star and/or WPSD that explains why `/lib` is the better choice, then feel free to ignore this pull request.  No matter where the unit file is located, it will run no differently.